### PR TITLE
add an optional 'noAuthCache' flag

### DIFF
--- a/lib/svn.js
+++ b/lib/svn.js
@@ -25,7 +25,9 @@ Client.prototype.cmd = function(params, callback) {
     if (this.getOption('password') !== undefined) {
         params.push('--password', this.getOption('password'));
     }
-
+    if (this.getOption('noAuthCache') === true) {
+        params.push('--no-auth-cache');
+    }
     return Client.super_.prototype.cmd.call(this, params, callback);
 };
 


### PR DESCRIPTION
When 'username' and 'password' flags are used without no-auth-cache, the logged in user on the machine is overridden. This is not an issue on a server, but in development environment it's very annoying. This optional flag will enable developers to access restricted repositories without changing the logged in user on their machine.
